### PR TITLE
Better Support MacVim and Multi-Maven Projects

### DIFF
--- a/autoload/maven.vim
+++ b/autoload/maven.vim
@@ -267,7 +267,11 @@ function! <SID>LookForMavenProjectRoot(srcPath)
 endfunction
 
 function! <SID>SetProjectRootToBuffer(buf, rootPath)
-	call setbufvar(a:buf, "_mvn_project", a:rootPath)
+	if g:maven_detect_root == 1
+		call setbufvar(a:buf, "_mvn_project", a:rootPath)
+	else
+		call setbufvar(a:buf, "_mvn_project", getcwd())
+	endif
 endfunction
 
 function! <SID>SetupOutputFile(targetBuf)

--- a/plugin/maven.vim
+++ b/plugin/maven.vim
@@ -30,14 +30,17 @@ endif
 if !exists("g:maven_keymaps")
     let g:maven_keymaps = 0
 endif
+if !exists("g:maven_detect_root")
+  let g:maven_detect_root = 1
+endif
 " }}}
 
 " Maps {{{
 if g:maven_keymaps
-    nnoremap <silent> <unique> maven#run-unittest :Mvn test -Dtest=%:t:r -DfailIfNoTests=true<CR>
-    inoremap <silent> <unique> maven#run-unittest <C-O>:Mvn test -Dtest=%:t:r -DfailIfNoTests=true<CR>
-    nnoremap <silent> <unique> maven#run-unittest-all :Mvn test -DfailIfNoTests=true<CR>
-    inoremap <silent> <unique> maven#run-unittest-all <C-O>:Mvn test -DfailIfNoTests=true<CR>
+    nnoremap <silent> <unique> maven#run-unittest :Mvn test -Dtest=%:t:r -DfailIfNoTests=false --offline<CR>:redraw!<CR>
+    inoremap <silent> <unique> maven#run-unittest <C-O>:Mvn test -Dtest=%:t:r -DfailIfNoTests=false --offline<CR>:redraw!<CR>
+    nnoremap <silent> <unique> maven#run-unittest-all :Mvn test -DfailIfNoTests=true<CR>:redraw!<CR>
+    inoremap <silent> <unique> maven#run-unittest-all <C-O>:Mvn test -DfailIfNoTests=true<CR>:redraw!<CR>
     nnoremap <silent> <unique> maven#switch-unittest-file :call <SID>SwitchUnitTest()<CR>
     inoremap <silent> <unique> maven#switch-unittest-file <C-O>:call <SID>SwitchUnitTest()<CR>
     nnoremap <silent> <unique> maven#open-test-result :call <SID>OpenTestResult()<CR>


### PR DESCRIPTION
Option to not auto discover maven root
--------------------------------------
In multi maven projects it can be helpful to assume that the directoy the
editor has been set to can be assumed to be the maven root since otherwise
only a subproject would be built causing build failures where there should
not be any.

This is enabled via the `g:maven_detect_root` which defaults to `1` for
true but can be set to `0` making the current directory the maven root.

Fix screen redraw on MacVim + Tmux
----------------------------------
In a MacVim running in Tmux the screen gets not redrawn correctly after the
`Mvn` commands return, to fix this `redraw!` needs to be called, this
automates this for the default actions affected.