### PR TITLE
Add option to disable certain autocommands

### DIFF
--- a/doc/maven.txt
+++ b/doc/maven.txt
@@ -216,6 +216,10 @@ could turn off this function by setting |g:maven_auto_set_path| to 0.
 
 See: |:find|
 
+By default, this plugin registers generic |BufNewFile| and |BufReadPost|
+autocommands to alter |path| and |compiler|.  To disable these autocommands set
+|g:maven_auto_buffer_setup| to 0.
+
 ==============================================================================
 1.5. Writing unit test			*maven-tutorial-writing-unittest*
 
@@ -481,6 +485,10 @@ so that these functions is context-free from your editing.
 
 Functions for Maven Information ~
 
+maven#SetupMavenEnv()					*maven#SetupMavenEnv()*
+	Check whether the current buffer is under a Maven project, and alter |path|
+	and |compiler| accordingly.
+
 maven#isBufferUnderMavenProject(buf)					*maven#isBufferUnderMavenProject()*
 	Check whether a buffer is under a Maven project. This inspection of a
 	buffer for Maven is trigger by |BufReadPost| and |BufNewFile| events of
@@ -645,6 +653,12 @@ g:maven_auto_chdir				*maven-auto-chdir* *g:maven_auto_chdir*
 
 		If this value is 1, this plugin would use |:lcd| to switch the current
 		directory on <project_root>. This action is triggered by |BufWinEnter+|
+
+g:maven_auto_buffer_setup	*maven-auto-buffer-setup* *g:maven_auto_buffer_setup*
+		Default value: 1
+
+		If this value is 1, this plugin would call |maven#SetupMavenEnv()| on
+		|BufNewFile| or |BufReadPost|
 
 ==============================================================================
 2.5. Maven Options for Unit Test	*maven-plugin-options-unittest*

--- a/plugin/maven.vim
+++ b/plugin/maven.vim
@@ -33,6 +33,9 @@ endif
 if !exists("g:maven_detect_root")
   let g:maven_detect_root = 1
 endif
+if !exists("g:maven_auto_buffer_setup")
+	let g:maven_auto_buffer_setup = 1
+endif
 " }}}
 
 " Maps {{{
@@ -50,7 +53,9 @@ endif
 
 " Autocmds {{{
 augroup MavenAutoDetect
-autocmd MavenAutoDetect BufNewFile,BufReadPost *.* call s:SetupMavenEnv()
+if g:maven_auto_buffer_setup
+	autocmd MavenAutoDetect BufNewFile,BufReadPost *.* call maven#SetupMavenEnv()
+endif
 autocmd MavenAutoDetect BufWinEnter *.* call s:AutoChangeCurrentDirOfWindow()
 autocmd MavenAutoDetect QuickFixCmdPost make call s:ProcessQuickFixForMaven()
 " }}}
@@ -110,7 +115,7 @@ menu <silent> Plugin.maven.Phrase.Site.site-deploy :Mvn site-deploy<CR>
 " }}}
 
 " Setup the maven environment for current buffer
-function! <SID>SetupMavenEnv()
+function! maven#SetupMavenEnv()
 	let currentBuffer = bufnr("%")
 
     call maven#setupMavenProjectInfo(currentBuffer)


### PR DESCRIPTION
Sometimes I work on projects where Maven is only used to package things up and not to compile source files, and this plugin's default autocommands can really mess things up (especially when they start changing buffers `compiler` options).  This PR adds an option to disable some of these autocommands, and expose `SetupMavenEnv()`.