### PR TITLE
Support file-level warnings and errors

### DIFF
--- a/compiler/maven.vim
+++ b/compiler/maven.vim
@@ -31,6 +31,8 @@ CompilerSet errorformat=
 	\[%tRROR]%\\s%#Malformed\ POM\ %\\f%\\+:%m@\ %f\\,\ line\ %l\\,\ column\ %c%.%#,
     \[%tRROR]\ %f:[%l\\,%c]\ %m,
     \[%tARNING]\ %f:[%l\\,%c]\ %m,
+    \[%tRROR]\ %f:\ %m,
+    \[%tARNING]\ %f:\ %m,
     \[%tRROR]\ %m,
     \[%tARNING]\ %m,
 	\Failed\ tests:%\\s%#%s(%f):\ %m,


### PR DESCRIPTION
FWIW, I am running Apache Maven 3.5.3, but I don't remember when this kind of formats were added