### PR TITLE
Fix lokup when root directory path contains src

### DIFF
--- a/plugin/maven.vim
+++ b/plugin/maven.vim
@@ -360,7 +360,7 @@ function! <SID>ConvertToFilePathForNewTest(subFoldersOfTest, listOfCandidates, f
 
 endfunction
 function! <SID>ConvertToFilePathForSource(testClassName, fileDir, fileExtension)
-	let fileDir = substitute(a:fileDir, '/src/[^/]\+/', '/src/main/', '')
+	let fileDir = substitute(a:fileDir, '.*\zs/src/[^/]\+/', '/src/main/', '')
 
 	" Convert the class name of test code to class name of source code
 	for matchPattern in s:BuildMatchPattersForTestClass()


### PR DESCRIPTION
When switching between Test and Source file, if the root path already has `/src/` somewhere in the path, the lookup fails (results in the wrong path).

This patch makes sure that during the original fileDir lookup we consume most of the path and only replace the last occurence of `src`